### PR TITLE
Feature: DFU improvements

### DIFF
--- a/squishy/core/device.py
+++ b/squishy/core/device.py
@@ -7,7 +7,7 @@ from datetime                            import datetime
 
 from usb1                                import USBContext, USBDevice, USBError, USBConfiguration
 from usb1.libusb1                        import (
-	LIBUSB_ERROR_IO, LIBUSB_ERROR_NO_DEVICE
+	LIBUSB_REQUEST_TYPE_CLASS, LIBUSB_RECIPIENT_INTERFACE, LIBUSB_ERROR_IO, LIBUSB_ERROR_NO_DEVICE
 )
 
 from usb_construct.types                 import LanguageIDs
@@ -77,7 +77,7 @@ class SquishyHardwareDevice:
 		self._ensure_iface_claimed(interface_id)
 
 		data: bytearray | None = self._usb_hndl.controlRead(
-			0b00100001,
+			LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_INTERFACE,
 			DFURequests.GetStatus,
 			0,
 			interface_id,
@@ -99,7 +99,7 @@ class SquishyHardwareDevice:
 		self._ensure_iface_claimed(interface_id)
 
 		data: bytearray | None = self._usb_hndl.controlRead(
-			0b00100001,
+			LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_INTERFACE,
 			DFURequests.GetState,
 			0,
 			interface_id,
@@ -122,7 +122,7 @@ class SquishyHardwareDevice:
 
 		try:
 			sent: int = self._usb_hndl.controlWrite(
-				0b00100001,
+				LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_INTERFACE,
 				DFURequests.Detach,
 				0,
 				interface_id,
@@ -230,7 +230,7 @@ class SquishyHardwareDevice:
 		self._ensure_iface_claimed(interface_id)
 
 		sent: int = self._usb_hndl.controlWrite(
-			0b00100001,
+			LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_INTERFACE,
 			DFURequests.Download,
 			chunk_num,
 			interface_id,

--- a/squishy/core/device.py
+++ b/squishy/core/device.py
@@ -231,8 +231,6 @@ class SquishyHardwareDevice:
 			data,
 			self._timeout
 		)
-
-
 		return sent == len(data)
 
 	def _ensure_iface_claimed(self, id: int) -> None:
@@ -242,9 +240,14 @@ class SquishyHardwareDevice:
 
 	def _ensure_iface_released(self, id: int) -> None:
 		if id in self._claimed_interfaces:
-			self._usb_hndl.releaseInterface(id)
 			self._claimed_interfaces.remove(id)
-
+			# If this throws an exception that matches the no-device condition, turn that into a
+			# "nothing to see here" as that just means the device is rebooting
+			try:
+				self._usb_hndl.releaseInterface(id)
+			except USBError as error:
+				if error.value != LIBUSB_ERROR_NO_DEVICE:
+					raise
 
 	def can_dfu(self) -> bool:
 		''' Check to see if the Device can DFU '''

--- a/squishy/core/device.py
+++ b/squishy/core/device.py
@@ -56,7 +56,10 @@ class SquishyHardwareDevice:
 				for iface in cfg:
 					for ifset in iface:
 						if ifset.getClassTuple() == DFU_CLASS:
-							self._dfu_iface = ifset.getNumber()
+							self._dfu_cfg: int = cfg.getConfigurationValue()
+							self._dfu_iface: int = ifset.getNumber()
+							if self._usb_hndl.getConfiguration() != self._dfu_cfg:
+								self._usb_hndl.setConfiguration(self._dfu_cfg)
 							return self._dfu_iface
 
 		return self._dfu_iface
@@ -259,6 +262,7 @@ class SquishyHardwareDevice:
 		if not self.can_dfu():
 			raise RuntimeError(f'The device {dev.getVendorID():04x}:{dev.getProductID():04x} @ {dev.getBusNumber()} is not DFU capable.')
 		self._timeout: int          = timeout
+		self._dfu_cfg: int | None = None
 		self._dfu_iface: int | None = None
 		self.serial   = serial
 		self.raw_ver  = dev.getbcdDevice()

--- a/squishy/core/device.py
+++ b/squishy/core/device.py
@@ -5,7 +5,7 @@ from typing                              import Iterable, Type
 from time                                import sleep
 from datetime                            import datetime
 
-from usb1                                import USBContext, USBDevice, USBError, USBConfiguration
+from usb1                                import USBContext, USBDevice, USBError
 from usb1.libusb1                        import (
 	LIBUSB_REQUEST_TYPE_CLASS, LIBUSB_RECIPIENT_INTERFACE, LIBUSB_ERROR_IO, LIBUSB_ERROR_NO_DEVICE
 )
@@ -52,7 +52,7 @@ class SquishyHardwareDevice:
 
 	'''
 
-	def _get_dfu_interface(self, cfg: USBConfiguration | None) -> int | None:
+	def _get_dfu_interface(self, cfg: int | None) -> int | None:
 		''' Get the interface ID that matches the ``_DFU_CLASS`` '''
 		if self._dfu_iface is None and cfg is not None:
 			for cfg in self._dev.iterConfigurations():
@@ -69,8 +69,7 @@ class SquishyHardwareDevice:
 
 	def _get_dfu_status(self) -> tuple[DFUStatus, DFUState]:
 		''' Get DFU Status '''
-		cfg = self._usb_hndl.getConfiguration()
-		interface_id = self._get_dfu_interface(cfg)
+		interface_id = self._get_dfu_interface(self._dfu_cfg)
 		if interface_id is None:
 			raise RuntimeError('Unable to get interface ID for DFU Device')
 
@@ -91,8 +90,7 @@ class SquishyHardwareDevice:
 
 	def _get_dfu_state(self) -> DFUState:
 		''' Get the DFU State '''
-		cfg = self._usb_hndl.getConfiguration()
-		interface_id = self._get_dfu_interface(cfg)
+		interface_id = self._get_dfu_interface(self._dfu_cfg)
 		if interface_id is None:
 			raise RuntimeError('Unable to get interface ID for DFU Device')
 
@@ -113,8 +111,7 @@ class SquishyHardwareDevice:
 
 	def _send_dfu_detach(self) -> bool:
 		''' Invoke a DFU Detach '''
-		cfg = self._usb_hndl.getConfiguration()
-		interface_id = self._get_dfu_interface(cfg)
+		interface_id = self._get_dfu_interface(self._dfu_cfg)
 		if interface_id is None:
 			raise RuntimeError('Unable to get interface ID for DFU Device')
 
@@ -147,8 +144,7 @@ class SquishyHardwareDevice:
 		''' Get the DFU alt-modes '''
 		log.debug('Getting DFU alt-modes')
 
-		cfg = self._usb_hndl.getConfiguration()
-		interface_id  = self._get_dfu_interface(cfg)
+		interface_id  = self._get_dfu_interface(self._dfu_cfg)
 		if interface_id is None:
 			raise RuntimeError('Unable to get interface ID for DFU Device')
 
@@ -171,8 +167,7 @@ class SquishyHardwareDevice:
 
 	def _get_dfu_tx_size(self) -> int | None:
 		''' Get the DFU transaction size '''
-		cfg = self._usb_hndl.getConfiguration()
-		interface_id = self._get_dfu_interface(cfg)
+		interface_id = self._get_dfu_interface(self._dfu_cfg)
 		if interface_id is None:
 			raise RuntimeError('Unable to get interface ID for DFU Device')
 
@@ -222,8 +217,7 @@ class SquishyHardwareDevice:
 	def _send_dfu_download(self, data: bytearray, chunk_num: int) -> bool:
 		''' Send a DFU Download transaction '''
 
-		cfg = self._usb_hndl.getConfiguration()
-		interface_id = self._get_dfu_interface(cfg)
+		interface_id = self._get_dfu_interface(self._dfu_cfg)
 		if interface_id is None:
 			raise RuntimeError('Unable to get interface ID for DFU Device')
 
@@ -450,8 +444,7 @@ class SquishyHardwareDevice:
 
 		log.info(f'Starting DFU upload of {len(data)} bytes to slot {slot}')
 
-		cfg = self._usb_hndl.getConfiguration()
-		interface_id = self._get_dfu_interface(cfg)
+		interface_id = self._get_dfu_interface(self._dfu_cfg)
 		if interface_id is None:
 			raise RuntimeError('Unable to get interface ID for DFU Device')
 


### PR DESCRIPTION
After winding up using Squishy's host-side DFU implementation as a basis to test another project's DFU bootloader and be able to step through operations in parts, we wound up discovering some ways it could be improved on and made more robust.

This PR is the culmination of this discovery, resulting in more robust handling of multiple configurations, should they arise, and affirmatively re-finding the DFU interface descriptors as needed when diving them for additional information. This also improves on error reporting and handling during DFU_DETACH and when handling releasing claimed interfaces when the device might have rebooted